### PR TITLE
fix: гардероб ведущего врача открыт всем врачам (сняты таймеры)

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -1,6 +1,9 @@
 # Head
 - type: loadout
-  id: SeniorPhysicianBeret # Fish-edit
+  id: SeniorPhysicianBeret # Fish-edit - Возврат требования старшего врача
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SeniorPhysician
   equipment:
     head: ClothingHeadHatBeretSeniorPhysician
 
@@ -49,12 +52,18 @@
     jumpsuit: ClothingUniformJumpskirtMedicalDoctor
 
 - type: loadout
-  id: SeniorPhysicianJumpsuit # Fish-edit
+  id: SeniorPhysicianJumpsuit # Fish-edit - Возврат требования старшего врача
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SeniorPhysician
   equipment:
     jumpsuit: ClothingUniformJumpsuitSeniorPhysician
 
 - type: loadout
-  id: SeniorPhysicianJumpskirt # Fish-edit
+  id: SeniorPhysicianJumpskirt # Fish-edit - Возврат требования старшего врача
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SeniorPhysician
   equipment:
     jumpsuit: ClothingUniformJumpskirtSeniorPhysician
 
@@ -96,7 +105,10 @@
     outerClothing: ClothingOuterWinterMed
 
 - type: loadout
-  id: SeniorPhysicianLabCoat # Fish-edit
+  id: SeniorPhysicianLabCoat # Fish-edit - Возврат требования старшего врача
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SeniorPhysician
   equipment:
     outerClothing: ClothingOuterCoatLabSeniorPhysician
 
@@ -113,7 +125,10 @@
     id: MedicalPDA
 
 - type: loadout
-  id: SeniorPhysicianPDA # Fish-edit
+  id: SeniorPhysicianPDA # Fish-edit - Возврат требования старшего врача
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SeniorPhysician
   equipment:
     id: SeniorPhysicianPDA
 

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -1,9 +1,6 @@
 # Head
 - type: loadout
-  id: SeniorPhysicianBeret
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysician
+  id: SeniorPhysicianBeret # Fish-edit
   equipment:
     head: ClothingHeadHatBeretSeniorPhysician
 
@@ -52,18 +49,12 @@
     jumpsuit: ClothingUniformJumpskirtMedicalDoctor
 
 - type: loadout
-  id: SeniorPhysicianJumpsuit
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysician
+  id: SeniorPhysicianJumpsuit # Fish-edit
   equipment:
     jumpsuit: ClothingUniformJumpsuitSeniorPhysician
 
 - type: loadout
-  id: SeniorPhysicianJumpskirt
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysician
+  id: SeniorPhysicianJumpskirt # Fish-edit
   equipment:
     jumpsuit: ClothingUniformJumpskirtSeniorPhysician
 
@@ -105,10 +96,7 @@
     outerClothing: ClothingOuterWinterMed
 
 - type: loadout
-  id: SeniorPhysicianLabCoat
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysician
+  id: SeniorPhysicianLabCoat # Fish-edit
   equipment:
     outerClothing: ClothingOuterCoatLabSeniorPhysician
 
@@ -125,10 +113,7 @@
     id: MedicalPDA
 
 - type: loadout
-  id: SeniorPhysicianPDA
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysician
+  id: SeniorPhysicianPDA # Fish-edit
   equipment:
     id: SeniorPhysicianPDA
 

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -850,6 +850,10 @@
   loadouts:
   - YellowJumpsuit
   - YellowJumpskirt
+  # Fish-start - Вещи ведущего инженера
+  - SeniorEngineerJumpsuit
+  - SeniorEngineerJumpskirt
+  # Fish-end
 
 #- type: loadoutGroup
 #  id: TechnicalAssistantJobTrinkets
@@ -873,6 +877,10 @@
   - StationEngineerJumpsuit
   - StationEngineerJumpskirt
   - StationEngineerHazardsuit
+  # Fish-start - Вещи ведущего инженера
+  - SeniorEngineerJumpsuit
+  - SeniorEngineerJumpskirt
+  # Fish-end
 
 - type: loadoutGroup
   id: StationEngineerBackpack
@@ -916,6 +924,10 @@
   - AtmosphericTechnicianJumpsuit
   - AtmosphericTechnicianJumpskirt
   - AtmosphericTechnicianJumpsuitCasual
+  # Fish-start - Вещи ведущего инженера
+  - SeniorEngineerJumpsuit
+  - SeniorEngineerJumpskirt
+  # Fish-end
 
 - type: loadoutGroup
   id: AtmosphericTechnicianOuterClothing
@@ -1014,6 +1026,10 @@
   loadouts:
   - ScientistJumpsuit
   - ScientistJumpskirt
+  # Fish-start - Вещи ведущего учёного
+  - SeniorResearcherJumpsuit
+  - SeniorResearcherJumpskirt
+  # Fish-end
 
 - type: loadoutGroup
   id: ScientistBackpack
@@ -1031,6 +1047,9 @@
   - RegularLabCoat
   - ScienceLabCoat
   - ScienceWintercoat
+  # Fish-start - Вещи ведущего учёного
+  - SeniorResearcherLabCoat
+  # Fish-end
 
 - type: loadoutGroup
   id: ScientistShoes
@@ -1067,6 +1086,10 @@
   loadouts:
   - WhiteJumpsuit
   - WhiteJumpskirt
+  # Fish-start - Вещи ведущего учёного
+  - SeniorResearcherJumpsuit
+  - SeniorResearcherJumpskirt
+  # Fish-end
 
 #- type: loadoutGroup
 #  id: ResearchAssistantJobTrinkets
@@ -1130,6 +1153,10 @@
   loadouts:
   - WardenJumpsuit
   - WardenJumpskirt
+  # Fish-start - Вещи старшего офицера
+  - SeniorOfficerJumpsuit
+  - SeniorOfficerJumpskirt
+  # Fish-end
 
 - type: loadoutGroup
   id: WardenOuterClothing
@@ -1163,6 +1190,10 @@
   - SecurityJumpsuitGrey
   - SecurityJumpskirtGrey
   - TrooperUniform
+  # Fish-start - Вещи старшего офицера
+  - SeniorOfficerJumpsuit
+  - SeniorOfficerJumpskirt
+  # Fish-end
 
 - type: loadoutGroup
   id: SecurityBackpack
@@ -1231,6 +1262,10 @@
   - DetectiveJumpskirt
   - NoirJumpsuit
   - NoirJumpskirt
+  # Fish-start - Вещи старшего офицера
+  - SeniorOfficerJumpsuit
+  - SeniorOfficerJumpskirt
+  # Fish-end
 
 - type: loadoutGroup
   id: DetectiveOuterClothing
@@ -1253,6 +1288,10 @@
   loadouts:
   - RedJumpsuit
   - RedJumpskirt
+  # Fish-start - Вещи старшего офицера
+  - SeniorOfficerJumpsuit
+  - SeniorOfficerJumpskirt
+  # Fish-end
 
 #- type: loadoutGroup
 #  id: SecurityCadetJobTrinkets

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/medical.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/medical.yml
@@ -137,6 +137,10 @@
   loadouts:
   - WhiteJumpsuit
   - WhiteJumpskirt
+  # Fish-start - Вещи ведущего врача
+  - SeniorPhysicianJumpsuit
+  - SeniorPhysicianJumpskirt
+  # Fish-end
 
 #- type: loadoutGroup
 #  id: MedicalInternJobTrinkets
@@ -152,6 +156,10 @@
   loadouts:
   - ChemistJumpsuit
   - ChemistJumpskirt
+  # Fish-start - Вещи ведущего врача
+  - SeniorPhysicianJumpsuit
+  - SeniorPhysicianJumpskirt
+  # Fish-end
 
 - type: loadoutGroup
   id: ChemistOuterClothing
@@ -161,6 +169,9 @@
   - RegularLabCoat
   - ChemistLabCoat
   - ChemistWintercoat
+  # Fish-start - Вещи ведущего врача
+  - SeniorPhysicianLabCoat
+  # Fish-end
 
 - type: loadoutGroup
   id: ChemistBackpack
@@ -191,6 +202,10 @@
   loadouts:
   - ParamedicJumpsuit
   - ParamedicJumpskirt
+  # Fish-start - Вещи ведущего врача
+  - SeniorPhysicianJumpsuit
+  - SeniorPhysicianJumpskirt
+  # Fish-end
 
 - type: loadoutGroup
   id: ParamedicOuterClothing

--- a/Resources/Prototypes/_Sunrise/Loadouts/Pools/Sunrise/Loadouts/Medical/senior_physician.yml
+++ b/Resources/Prototypes/_Sunrise/Loadouts/Pools/Sunrise/Loadouts/Medical/senior_physician.yml
@@ -40,17 +40,11 @@
       time: 216000 # 60 hrs
 
 - type: loadout
-  id: BeretSeniorPhysician
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysicianClothingTimer
+  id: BeretSeniorPhysician # Fish-edit
   equipment:
     head: ClothingHeadHatBeretSeniorPhysician
 
 - type: loadout
-  id: CoatLabSeniorPhysician
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysicianClothingTimer
+  id: CoatLabSeniorPhysician # Fish-edit
   equipment:
     outerClothing: ClothingOuterCoatLabSeniorPhysician

--- a/Resources/Prototypes/_Sunrise/Loadouts/Pools/Sunrise/Loadouts/Medical/senior_physician.yml
+++ b/Resources/Prototypes/_Sunrise/Loadouts/Pools/Sunrise/Loadouts/Medical/senior_physician.yml
@@ -40,11 +40,17 @@
       time: 216000 # 60 hrs
 
 - type: loadout
-  id: BeretSeniorPhysician # Fish-edit
+  id: BeretSeniorPhysician # Fish-edit - Возврат требования
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SeniorPhysicianClothingTimer
   equipment:
     head: ClothingHeadHatBeretSeniorPhysician
 
 - type: loadout
-  id: CoatLabSeniorPhysician # Fish-edit
+  id: CoatLabSeniorPhysician # Fish-edit - Возврат требования
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SeniorPhysicianClothingTimer
   equipment:
     outerClothing: ClothingOuterCoatLabSeniorPhysician


### PR DESCRIPTION
<!-- Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->

## Краткое описание
Гардероб ведущего врача (берет, комбинезон, юбка, лабораторный халат, КПК) теперь доступен всем врачам без условия наигранного времени - по аналогии с комбинезоном, который уже был открыт ранее. Должность ведущего врача остаётся закрытой прежними требованиями по времени.
Для интернов форма по-прежнему недоступна.

:cl: Kaiten
- tweak: После абильного нытья от игроков в ахелп. Вещи ведущих ролей добавлены другим должностям в отделе после и доступны после открытия ведущей роли.
:end-cl: