### PR TITLE
Нерфы мурмилло

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -632,12 +632,12 @@
       coefficients:
         Blunt: 0.4
         Slash: 0.3
-        Piercing: 0.2
+        Piercing: 0.3 # Fish-edit
         Heat: 0.4
         Radiation: 0.4
         Caustic: 0.4
       flatReductions:
-        Piercing: 9
+        Piercing: 2 # Fish-edit
   - type: StaminaResistance
     damageCoefficient: 0.2
   - type: ToggleableClothing

--- a/Resources/Prototypes/_Sunrise/Hardsuitinject/prototypes.yml
+++ b/Resources/Prototypes/_Sunrise/Hardsuitinject/prototypes.yml
@@ -235,6 +235,7 @@
           Quantity: 20
   - type: SolutionRegeneration
     solution: beaker
+    duration: 180 # Fish-edit
     generated:
       reagents:
       - ReagentId: DarkRedRum

--- a/Resources/Prototypes/_Sunrise/NPCs/PirateNPC/npc_loot_pirate.yml
+++ b/Resources/Prototypes/_Sunrise/NPCs/PirateNPC/npc_loot_pirate.yml
@@ -4167,12 +4167,12 @@
     - id: SunriseClothingShoesBootsMagPirateMurmilloDamaged
       prob: 0.25
       orGroup: MurmilloHardsuitPool
-    - id: SunriseClothingShoesBootsMagPirateMurmillo
-      prob: 0.5
+    - id: SunriseClothingShoesBootsMagPirateMurmillo # Fish-edit
+      prob: 0.6
       orGroup: MurmilloHardsuitPool
-    - id: SunriseClothingShoesBootsMagPirateMurmilloActive
-      prob: 0.1
-      orGroup: MurmilloHardsuitPool
+    # - id: SunriseClothingShoesBootsMagPirateMurmilloActive # Fish-edit
+    #   prob: 0.1
+    #   orGroup: MurmilloHardsuitPool
     - id: PirateMedSpawner03
     - id: WeaponCrusherBroadAxe
       prob: 0.7


### PR DESCRIPTION
<!-- Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->

## Краткое описание
<!--
Что вы предлагаете изменить с помощью своего PR?
-->

## Ссылка на багрепорт/Предложение
<!--
Ссылки на Дискуссии и Баг-репорты указывать здесь.
-->

## Медиа (Видео/Скриншоты)
<!-- changelog-media-section -->
<!--
Если ваш PR содержит внутриигровые изменения, вы обязаны предоставить скриншоты/видео изменений.
Обычный текст непосредственно перед изображением или видео станет его описанием.
Медиа из других разделов PR в чейнжлог не попадёт.
-->

<!--
## TODO

Не закончили? Добавьте список того, что требуется для завершения PR'а.

- [ ] Task 1
- [ ] Task 2
-->

<!--
## Требования к картам

Если ваше изменение требует изменение на картах - опишите требования тут.
Так мапперы серверов смогут понять, как адаптировать карты под ваши изменения.


-->

**Changelog**

<!--
=== КАК ПИСАТЬ ЧЕЙНЖЛОГ ===

[Подробная инструкция и полный пример](https://github.com/makura-games/sunrise-station/blob/master/Tools/_sunrise/changelog/README.md)

1) Не считайте тип чейнжлога частью вашего предложения.
add: Новая фича = ПЛОХО | add: Добавлена новая фича = ХОРОШО
2) Подробно описывайте, что вы добавили и как это использовать. Все должно быть в меру.
fix: Исправлены мелочи = УЖАСНО | fix: Исправлена невозможность игроков двигаться = ХОРОШО
3) Не добавляйте технические детали. Чейнжлог пишется для игроков.
add: Добавлен новый хелпер-метод = ПЛОХО | НИЧЕГО НЕ ПИСАТЬ = ХОРОШО
* Иногда чейнжлог не нужен. Просто удалите это поле.

Продолжайте текст записи на следующих строках; переносы сохранятся в Discord:
`fix: Первая строка исправления`
`Вторая строка той же записи`

-->

:cl: Kaiten
- add: Перезарядка в 3 минуты  для регенерации стимулятора в ампуле скафандра Мурмилло.
- remove: Выпадение активной версии MOD-ботинок Мурмилло  из ящика босса. Теперь просим ученых на ядра Р.И.Г.
- tweak: Параметры защиты скафандра Мурмилло : сопротивление колющему урону установлено на 70% c 80% а фиксированное снижение урона понижено до 2 единиц c 9.
- tweak: Вероятность выпадения неактивных MOD-ботинок Мурмилло из ящика босса увеличена с 0.5 до 0.6.
- fix: Исправлена практически мгновенная перезарядка ампулы скафандра Мурмилло (была 1 секунда).
:end-cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Изменения игрового баланса**
  - Скорректирована защита скафандра «Мурмилло» от колющего урона: увеличен коэффициент защиты и уменьшено плоское снижение урона.
  - Для ампулы «Мурмилло» задана длительность цикла регенерации раствора — 180 секунд.

- **Изменения добычи**
  - Увеличена вероятность выпадения ботинок «Мурмилло» из соответствующего лута.
  - Активная версия этих ботинок исключена из пула добычи.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->